### PR TITLE
remove javascript alert when DND has been seen

### DIFF
--- a/Tag_google_analytics.js
+++ b/Tag_google_analytics.js
@@ -241,7 +241,6 @@ tagAnalyticsCNIL.CookieConsent = function() {
 			if (!consentCookie) {//L'utilisateur n'a pas encore de cookie, on affiche la banniére et si il clique sur un autre élément que la banniére, on enregistre le consentement
 				if ( notToTrack() ) { //L'utilisateur a activé DoNotTrack. Do not ask for consent and just opt him out
 					tagAnalyticsCNIL.CookieConsent.gaOptout()
-					alert("You've enabled DNT, we're respecting your choice")
 				} else {
 					if (isToTrack() ) { //DNT is set to 0, no need to ask for consent just set cookies
 						consent();


### PR DESCRIPTION
Hello,

I think we should remove the javascript alert which is currently triggered when an user is browser with DNT option.

Edouard
